### PR TITLE
fix: Fixed an issue where the url is encoded twice

### DIFF
--- a/src/imagetransforms/ImgixImageTransform.php
+++ b/src/imagetransforms/ImgixImageTransform.php
@@ -310,7 +310,7 @@ class ImgixImageTransform extends ImageTransform
         if ($fs instanceof Local) {
             $assetUrl = AssetsHelper::generateUrl($fs, $asset);
 
-            return parse_url($assetUrl, PHP_URL_PATH);
+            return parse_url(rawurldecode($assetUrl), PHP_URL_PATH);
         }
 
         return parent::getAssetUri($asset);


### PR DESCRIPTION
The `imgix/imgix-php` library expects a decoded path because it encodes the path in `Imgix/UrlHelper::formatPath`. 
https://github.com/imgix/imgix-php/blob/b42231e6e249e57592c474b08f79fe67d34615d8/src/UrlHelper.php#L26
Failure to pass a decoded path may result in issues such as double-encoding characters like `%`.

Example:
/products/riese-**müller**-load-75-vario-enviolo-intuvia-bagagedrager-load-twee-kinderzitjes-lage-zijwanden-white-2023/Load-75-Vario-Enviolo.jpeg

Should become:
/products/riese-**m%C3%BCller**-load-75-vario-enviolo-intuvia-bagagedrager-load-twee-kinderzitjes-lage-zijwanden-white-2023/Load-75-Vario-Enviolo.jpeg

Previous output:
/products/riese-**m%25C3%25BCller**-load-75-vario-enviolo-intuvia-bagagedrager-load-twee-kinderzitjes-lage-zijwanden-white-2023/Load-75-Vario-Enviolo.jpeg
