### PR TITLE
Parse API key environment variable before checking length

### DIFF
--- a/src/imagetransforms/ImgixImageTransform.php
+++ b/src/imagetransforms/ImgixImageTransform.php
@@ -245,6 +245,9 @@ class ImgixImageTransform extends ImageTransform
             );
             return false;
         }
+        
+        $apiKey = App::parseEnv($apiKey);
+        
         // Check the API key to see if it is deprecated or not
         if (strlen($this->apiKey) < 50) {
             try {
@@ -254,7 +257,6 @@ class ImgixImageTransform extends ImageTransform
             }
         }
 
-        $apiKey = App::parseEnv($apiKey);
         // create new guzzle client
         $guzzleClient = Craft::createGuzzleClient(['timeout' => 120, 'connect_timeout' => 120]);
         // Submit the sitemap index to each search engine


### PR DESCRIPTION
The API key environment variable must be parsed before checking its length, otherwise the deprecation check results in false positives.