### PR TITLE
Fixes purging bug in Imgix integration

### DIFF
--- a/src/imagetransforms/ImgixImageTransform.php
+++ b/src/imagetransforms/ImgixImageTransform.php
@@ -249,7 +249,7 @@ class ImgixImageTransform extends ImageTransform
         $apiKey = App::parseEnv($apiKey);
         
         // Check the API key to see if it is deprecated or not
-        if (strlen($this->apiKey) < 50) {
+        if (strlen($apiKey) < 50) {
             try {
                 Craft::$app->deprecator->log(__METHOD__, 'You are using a deprecated API key. Obtain a new API key to use the purging API. More info: https://blog.imgix.com/2020/10/16/api-deprecation');
             } catch (DeprecationException $e) {
@@ -265,7 +265,7 @@ class ImgixImageTransform extends ImageTransform
                 'headers' => [
                     'Authorization' => 'Bearer ' . $apiKey,
                 ],
-                'form_params' => [
+                'json' => [
                     'data' => [
                         'attributes' => [
                             'url' => $url


### PR DESCRIPTION
### Description

Imgix purge action after an Edit Image action would fail because $this->api_key is `$IMGIX_API_KEY` instead of the actual parsed key from some lines above. This would fail the `strlen` test. The parsed key $api_key is now checked, and doesn't break the purge action.

Furthermore sending data via Guzzle `json` in stead of `form_params` in order to fix t a 400 Bad Request response on the Imgix endpoint.

### Related issues

Fixes issue https://github.com/nystudio107/craft-imageoptimize/issues/273